### PR TITLE
Retry logic for status polling, downloads, and partial download service

### DIFF
--- a/rdgen_cli.py
+++ b/rdgen_cli.py
@@ -13,6 +13,10 @@ MAX_TIME_CHECKING_SEC    = 7200
 LOCAL_DOWNLOADS_DIR  = "downloads"
 
 MAX_REQUEST_TRIES = 5
+MAX_POLL_RETRIES  = 3      # Retries for transient failures during status polling
+POLL_RETRY_DELAY  = 30     # Seconds to wait between poll retries
+MAX_DOWNLOAD_RETRIES = 3   # Retries for individual file downloads
+DOWNLOAD_RETRY_DELAY = 15  # Seconds to wait between download retries
 
 BODY_DATA_AS_FORM = "form"
 BODY_DATA_AS_JSON = "json"
@@ -93,10 +97,11 @@ def parseArguments():
     parser.add_argument("-v", "--verbose",          action="store_true", help="Increase output verbosity")
     parser.add_argument("-p", "--preserve-log",     action="store_true", help="Preserve build status log")
     parser.add_argument("-d", "--disable-download", action="store_true", help="Disable automatic result download")
+    parser.add_argument("--allow-partial",          action="store_true", help="Exit successfully even if some downloads fail (e.g. mac x86_64)")
 
     args = parser.parse_args()
 
-    return args.file, args.server, args.verbose, args.preserve_log, args.disable_download, args.set_version, args.set_platform
+    return args.file, args.server, args.verbose, args.preserve_log, args.disable_download, args.set_version, args.set_platform, args.allow_partial
 
 def parseBuildStageInfo(html):
     resultStatus = reBuildStatus.search(html)
@@ -205,19 +210,34 @@ def downloadFiles(links: list[str], path, verbose) -> int:
                 maxLen = max(maxLen, len(output))
                 print(output, end=" "*(maxLen - len(output)), flush=True)
             
-            response = requests.get(link, stream=True)
-            response.raise_for_status()
+            # Retry logic for individual file downloads
+            downloaded = False
+            for attempt in range(1, MAX_DOWNLOAD_RETRIES + 1):
+                try:
+                    response = requests.get(link, stream=True)
+                    response.raise_for_status()
 
-            with open(f"{path}/{filename}", 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+                    with open(f"{path}/{filename}", 'wb') as f:
+                        for chunk in response.iter_content(chunk_size=8192):
+                            f.write(chunk)
 
-            print(f"\r{preamble} File saved locally: {filename}")
+                    print(f"\r{preamble} File saved locally: {filename}")
+                    downloaded = True
+                    break
 
-            successCount += 1
+                except requests.exceptions.RequestException as e:
+                    if attempt < MAX_DOWNLOAD_RETRIES:
+                        print(f"\r{preamble} Download attempt {attempt}/{MAX_DOWNLOAD_RETRIES} failed: {e}")
+                        print(f"{preamble} Retrying in {DOWNLOAD_RETRY_DELAY}s...")
+                        time.sleep(DOWNLOAD_RETRY_DELAY)
+                    else:
+                        print(f"Error downloading {link}: {e} (all {MAX_DOWNLOAD_RETRIES} attempts failed)")
+
+            if downloaded:
+                successCount += 1
             
-        except requests.exceptions.RequestException as e:
-            print(f"Error downloading {link}: {e}")
+        except Exception as e:
+            print(f"Error processing download link {link}: {e}")
             continue
         
         idx += 1
@@ -239,7 +259,7 @@ def fatal(msg):
     sys.exit(-1)
 
 def main():
-    confFile, rdgenAddress, verbose, dontFlushStatusLog, dontDownloadResult, setVersion, setPlatform = parseArguments()
+    confFile, rdgenAddress, verbose, dontFlushStatusLog, dontDownloadResult, setVersion, setPlatform, allowPartial = parseArguments()
 
     if verbose:
         if dontFlushStatusLog:
@@ -326,10 +346,6 @@ def main():
     if downloadLinks is None:
         fatal("Problem getting download links")
 
-    checkForFileUrl = f"{rdgenBaseUrl}/check_for_file?filename={filename}&uuid={uuid}&platform={platform}"
-
-    print(f"Web-page link: {checkForFileUrl}")
-
     print("Printing download links up-front. The result will be accessible as soon as the build is done:")
     printBulletPoints(downloadLinks)    
     
@@ -339,11 +355,29 @@ def main():
 
     maxLen = 1
 
-    while True:
-        response = tryRequest("GET", checkForFileUrl, auth=basicAuth)
+    pollFailures = 0  # Track consecutive poll failures
 
-        if not isHttpSuccess(response.status_code):
-            fatal("Response was not successful from rdgen server")
+    while True:
+        response = tryRequest("GET", f"{rdgenBaseUrl}/check_for_file?filename={filename}&uuid={uuid}&platform={platform}", auth=basicAuth)
+
+        # Handle transient poll failures with retry
+        if response is None or not isHttpSuccess(response.status_code):
+            pollFailures += 1
+            if response is not None:
+                reason = f"HTTP {response.status_code}"
+            else:
+                reason = "Connection failed"
+
+            if pollFailures >= MAX_POLL_RETRIES:
+                fatal(f"Response was not successful from rdgen server ({reason}, {pollFailures} consecutive failures)")
+            
+            print(f"⚠ Poll failed ({reason}), retry {pollFailures}/{MAX_POLL_RETRIES} in {POLL_RETRY_DELAY}s...")
+            time.sleep(POLL_RETRY_DELAY)
+            elapsedSeconds += POLL_RETRY_DELAY
+            continue
+        
+        # Reset failure counter on success
+        pollFailures = 0
 
         pageTitle = getPageTitle(response.text)
 
@@ -414,7 +448,10 @@ def main():
         fatal(f"No files were downloaded {postamble}")
 
     if downloadedCount != filesToDownload:
-        fatal(f"Not all files have been downloaded {postamble}")
+        if allowPartial:
+            print(f"⚠ Not all files were downloaded {postamble}, continuing with partial results (--allow-partial)")
+        else:
+            fatal(f"Not all files have been downloaded {postamble}")
     
     print(f"Build result files downloaded locally: {savePath}")
     

--- a/rdgen_cli.py
+++ b/rdgen_cli.py
@@ -345,7 +345,11 @@ def main():
 
     if downloadLinks is None:
         fatal("Problem getting download links")
+        
+    checkForFileUrl = f"{rdgenBaseUrl}/check_for_file?filename={filename}&uuid={uuid}&platform={platform}"
 
+    print(f"Web-page link: {checkForFileUrl}")
+    
     print("Printing download links up-front. The result will be accessible as soon as the build is done:")
     printBulletPoints(downloadLinks)    
     
@@ -358,7 +362,7 @@ def main():
     pollFailures = 0  # Track consecutive poll failures
 
     while True:
-        response = tryRequest("GET", f"{rdgenBaseUrl}/check_for_file?filename={filename}&uuid={uuid}&platform={platform}", auth=basicAuth)
+        response = tryRequest("GET", checkForFileUrl, auth=basicAuth)
 
         # Handle transient poll failures with retry
         if response is None or not isHttpSuccess(response.status_code):

--- a/rdgen_cli.py
+++ b/rdgen_cli.py
@@ -12,7 +12,7 @@ MAX_TIME_CHECKING_SEC    = 7200
 
 LOCAL_DOWNLOADS_DIR  = "downloads"
 
-MAX_REQUEST_TRIES = 5
+MAX_REQUEST_TRIES = 5      # Retries for main requests (generator start and status polling)
 MAX_POLL_RETRIES  = 3      # Retries for transient failures during status polling
 POLL_RETRY_DELAY  = 30     # Seconds to wait between poll retries
 MAX_DOWNLOAD_RETRIES = 3   # Retries for individual file downloads
@@ -210,7 +210,6 @@ def downloadFiles(links: list[str], path, verbose) -> int:
                 maxLen = max(maxLen, len(output))
                 print(output, end=" "*(maxLen - len(output)), flush=True)
             
-            # Retry logic for individual file downloads
             downloaded = False
             for attempt in range(1, MAX_DOWNLOAD_RETRIES + 1):
                 try:
@@ -359,12 +358,11 @@ def main():
 
     maxLen = 1
 
-    pollFailures = 0  # Track consecutive poll failures
+    pollFailures = 0
 
     while True:
         response = tryRequest("GET", checkForFileUrl, auth=basicAuth)
 
-        # Handle transient poll failures with retry
         if response is None or not isHttpSuccess(response.status_code):
             pollFailures += 1
             if response is not None:
@@ -380,7 +378,6 @@ def main():
             elapsedSeconds += POLL_RETRY_DELAY
             continue
         
-        # Reset failure counter on success
         pollFailures = 0
 
         pageTitle = getPageTitle(response.text)


### PR DESCRIPTION
# Add retry logic for status polling, downloads, and partial download support

## Problem

When running `rdgen_cli` in automated batch scenarios (e.g. building multiple clients overnight), three failure modes cause unnecessary build losses:

### 1. Status polling has no retry on transient failures
The status polling loop calls `tryRequest()` which can return `None` on network errors or a non-2xx response on server hiccups. Currently, **any single failure immediately terminates** the entire build via `fatal()` — even if the build is still running fine on GitHub Actions.

This is especially problematic on cheap VPS instances or unstable networks where brief connectivity drops are common. A 30-minute build gets killed because of a 2-second network blip.

### 2. File downloads have no retry on server errors (HTTP 500)
The `downloadFiles()` function calls `response.raise_for_status()` once — if the server returns a 500, the download is marked as failed immediately with no retry attempt. 

**Observed behavior:** macOS x86_64 DMG downloads consistently fail with `500 Server Error` on the public rdgen server. This appears to be a transient/intermittent server-side issue (see #211) that often resolves on retry.

### 3. One failed download kills the entire build result
If even a single file out of many fails to download (e.g. 1 out of 2 macOS DMGs), the CLI calls `fatal()` and exits with an error code. The successfully downloaded files (e.g. the aarch64 DMG) are still on disk but the non-zero exit code signals complete failure to any calling script.

## Solution

### Status polling retry (consecutive failure tolerance)
- Track consecutive poll failures with a counter
- On failure: log a warning, wait 30s, retry (up to 3 times)
- On success: reset the failure counter
- Only call `fatal()` after 3 **consecutive** failures
- A single transient network drop no longer kills a running build

### Download retry per file
- Each individual file download is retried up to 3 times with 15s delay between attempts
- Only after all attempts fail is the file marked as failed
- Other files in the same build continue downloading regardless

### `--allow-partial` flag
- New CLI flag: `--allow-partial`
- When set: if some (but not all) downloads fail, the CLI prints a warning but **exits with code 0**
- When not set: behavior is unchanged (fatal on partial downloads) — fully backwards compatible
- Useful for macOS builds where x86_64 consistently fails but aarch64 succeeds

## New constants

```python
MAX_POLL_RETRIES  = 3      # Consecutive failures before giving up
POLL_RETRY_DELAY  = 30     # Seconds between poll retries
MAX_DOWNLOAD_RETRIES = 3   # Attempts per file download
DOWNLOAD_RETRY_DELAY = 15  # Seconds between download retries
```

## Usage

```bash
# Existing behavior (unchanged, fully backwards compatible)
python3 rdgen_cli.py -f config.json -s https://rdgen.example.com -v -p

# New: tolerate partial download failures (e.g. for macOS builds)
python3 rdgen_cli.py -f config.json -s https://rdgen.example.com -v -p --allow-partial
```

## Context

I run 6-8 custom client builds in parallel batches overnight using a wrapper script. Before this change, a typical overnight run would lose 3-5 builds to transient failures that would have succeeded on retry. The polling retry alone would have saved most of these, as the builds were still running on GitHub Actions — only the status check connection was briefly lost.